### PR TITLE
better way to add torrent, now working with private links

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "magnet-uri": "^5.1.5",
     "mega": "^0.2.0",
     "mime": "^1.3.4",
+    "parse-torrent": "^6.1.2",
     "pretty-bytes": "^4.0.2",
     "promise": "^7.1.1",
     "scrape-it": "^3.3.2",

--- a/server/server.js
+++ b/server/server.js
@@ -25,7 +25,7 @@ var parsetorrent = require('parse-torrent')
 //endregion
 //region Constants
 var PORT = Number(process.env.PORT || 3000);
-var FILES_PATH = path.join(__dirname, '../files');
+var FILES_PATH = process.env.FILES_PATH || path.join(__dirname, '../files');
 var SPEED_TICK_TIME = 750; //ms
 var TBP_PROXY = process.env["TBP_PROXY"] || "https://thepiratebay.rocks";
 debug("TBP Proxy: ", TBP_PROXY);
@@ -445,7 +445,12 @@ io.on('connection', function (client) {
                 value: true,
                 displayName: "Ask for filename when uploading files",
                 type: "checkbox"
-            }
+            },
+            autoUpload: {
+                value: true,
+                displayName: "Auto upload files when completed",
+                type: "checkbox"
+            },
         };
         session.save();
     }


### PR DESCRIPTION
The `parse-torrent` is a better way to get the torrent info and pass to `torrent-stream`.

Is the same lib used by [Peerflix](https://github.com/mafintosh/peerflix)

With this change, private trackers can be downloaded as well